### PR TITLE
Fix import section layout rendering

### DIFF
--- a/app.py
+++ b/app.py
@@ -7851,11 +7851,11 @@ def import_section(
             )
             .strip()
         )
-        st.markdown(section_html, unsafe_allow_html=True)
+        st.html(section_html)
         inner = st.container()
         with inner:
             yield
-        st.markdown("</div></section>", unsafe_allow_html=True)
+        st.html("</div></section>")
 
 
 def build_import_progress_steps() -> tuple[List[Dict[str, object]], Dict[str, str]]:


### PR DESCRIPTION
## Summary
- ensure the import section header HTML renders as DOM by switching to `st.html` wrappers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7a6513484832390c3954f6152024f