### PR TITLE
Fix metric card HTML rendering with st.html

### DIFF
--- a/app.py
+++ b/app.py
@@ -897,36 +897,34 @@ def render_metric_cards(
                 )
             class_attr = " ".join(classes)
             with col:
-                st.markdown(
-                    textwrap.dedent(
-                        """
-                        <div class="{classes}" role="group"{tooltip}{tab}{aria}>
-                          <div class="mck-metric-card__header">
-                            {icon}
-                            <div class="mck-metric-card__title-group">
-                              <div class="mck-metric-card__title">{title}</div>
-                              {subtitle}
-                            </div>
-                            {info}
-                          </div>
-                          <div class="mck-metric-card__value">{value}</div>
-                          {footnote}
+                card_html = textwrap.dedent(
+                    """
+                    <div class="{classes}" role="group"{tooltip}{tab}{aria}>
+                      <div class="mck-metric-card__header">
+                        {icon}
+                        <div class="mck-metric-card__title-group">
+                          <div class="mck-metric-card__title">{title}</div>
+                          {subtitle}
                         </div>
-                        """
-                    ).format(
-                        classes=class_attr,
-                        tooltip=tooltip_attr,
-                        tab=tab_attr,
-                        aria=aria_attr,
-                        icon=icon_block,
-                        title=title,
-                        subtitle=subtitle_html,
-                        info=info_html,
-                        value=value,
-                        footnote=footnote_html,
-                    ),
-                    unsafe_allow_html=True,
-                )
+                        {info}
+                      </div>
+                      <div class="mck-metric-card__value">{value}</div>
+                      {footnote}
+                    </div>
+                    """
+                ).format(
+                    classes=class_attr,
+                    tooltip=tooltip_attr,
+                    tab=tab_attr,
+                    aria=aria_attr,
+                    icon=icon_block,
+                    title=title,
+                    subtitle=subtitle_html,
+                    info=info_html,
+                    value=value,
+                    footnote=footnote_html,
+                ).strip()
+                st.html(card_html)
 
 
 def render_metric_bar_chart(metrics_list: List[Dict[str, object]]) -> None:


### PR DESCRIPTION
## Summary
- render metric cards using `st.html` so the header markup is treated as DOM instead of text

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7a79e59c08323b51446023bd381fe