### PR TITLE
Refine compare view layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -11559,9 +11559,8 @@ elif page == "比較ビュー":
         ]
     # ---- 操作バー＋グラフ密着カード ----
 
+    
     band_params_initial = params.get("band_params", {})
-    band_params = band_params_initial
-    amount_slider_cfg = None
     max_amount = int(snapshot["year_sum"].max()) if not snapshot.empty else 0
     low0 = int(
         band_params_initial.get(
@@ -11570,239 +11569,499 @@ elif page == "比較ビュー":
     )
     high0 = int(band_params_initial.get("high_amount", max_amount))
 
+    if "compare_details_open" not in st.session_state:
+        st.session_state.compare_details_open = False
+    if "compare_sensitivity" not in st.session_state:
+        st.session_state.compare_sensitivity = 0.5
+    if "compare_z_threshold" not in st.session_state:
+        st.session_state.compare_z_threshold = 0.0
+    if "compare_shape_pick" not in st.session_state:
+        st.session_state.compare_shape_pick = "（なし）"
+    st.session_state.setdefault("compare_quick", params.get("quick", "なし"))
+    st.session_state.setdefault("compare_label_avoid", True)
+    st.session_state.setdefault("compare_alternate_side", True)
+    st.session_state.setdefault("compare_label_gap", 12)
+    st.session_state.setdefault("compare_label_max", 12)
+    st.session_state.setdefault("compare_unit", "千円")
+    st.session_state.setdefault("compare_n_win", 6)
+    st.session_state.setdefault("compare_cmp_mode", "以上")
+    st.session_state.setdefault("compare_thr_type", "円/月")
+    st.session_state.setdefault("compare_thr_val_int", 0)
+    st.session_state.setdefault("compare_thr_val_float", 0.0)
+    st.session_state.setdefault("compare_period", "24ヶ月")
+    st.session_state.setdefault("compare_node_mode", "自動")
+    st.session_state.setdefault("compare_hover_mode", "個別")
+    st.session_state.setdefault("compare_op_mode", "パン")
+    st.session_state.setdefault("compare_peak_on", False)
+
+    default_band_mode = params.get("band_mode", "金額指定")
+    if "compare_band_mode" not in st.session_state:
+        st.session_state.compare_band_mode = default_band_mode
+    band_mode = st.session_state.get("compare_band_mode", default_band_mode)
+
+    band_params = params.get("band_params", {})
+    amount_slider_cfg = None
+
+    if band_mode == "金額指定":
+        if not snapshot.empty:
+            unit_scale, unit_label = choose_amount_slider_unit(max_amount)
+            slider_max = int(
+                math.ceil(
+                    max(
+                        max_amount,
+                        band_params.get("high_amount", high0),
+                        band_params.get("low_amount", low0),
+                    )
+                    / unit_scale
+                )
+            )
+            slider_max = max(slider_max, 1)
+            default_low = int(round(band_params.get("low_amount", low0) / unit_scale))
+            default_high = int(round(band_params.get("high_amount", high0) / unit_scale))
+            default_low = max(0, min(default_low, slider_max))
+            default_high = max(default_low, min(default_high, slider_max))
+            step = nice_slider_step(slider_max)
+            amount_slider_cfg = dict(
+                label=f"金額レンジ（{unit_label}単位）",
+                min_value=0,
+                max_value=slider_max,
+                value=(default_low, default_high),
+                step=step,
+                unit_scale=unit_scale,
+                unit_label=unit_label,
+                max_amount=max_amount,
+            )
+            st.session_state.setdefault("compare_amount_range", (default_low, default_high))
+        else:
+            band_params = {"low_amount": low0, "high_amount": high0}
+
     st.markdown(
         """
-  <style>
-  .chart-card { position: relative; margin:.35rem 0 1.2rem; border-radius:16px;
-    border:1px solid var(--border, rgba(var(--primary-rgb,11,31,59),0.18)); background:var(--panel,#ffffff);
-    box-shadow:0 16px 32px rgba(var(--primary-rgb,11,31,59),0.08); }
-  .chart-toolbar { position: sticky; top:-1px; z-index:5;
-    display:flex; gap:.6rem; flex-wrap:wrap; align-items:center;
-    padding:.45rem .75rem; background: linear-gradient(180deg, rgba(var(--accent-rgb,30,136,229),0.08), rgba(var(--accent-rgb,30,136,229),0.02));
-    border-bottom:1px solid var(--border, rgba(var(--primary-rgb,11,31,59),0.18)); }
-  /* Streamlit標準の下マージンを除去（ここが距離の主因） */
-  .chart-toolbar .stRadio, .chart-toolbar .stSelectbox, .chart-toolbar .stSlider,
-  .chart-toolbar .stMultiSelect, .chart-toolbar .stCheckbox { margin-bottom:0 !important; }
-  .chart-toolbar .stRadio > label, .chart-toolbar .stCheckbox > label { color:var(--ink,var(--primary,#0B1F3B)); font-weight:600; }
-  .chart-toolbar .stSlider label { color:var(--ink,var(--primary,#0B1F3B)); }
-  .chart-body { padding:.15rem .4rem .4rem; }
-  </style>
+<style>
+.compare-shell { margin-top: 0.75rem; }
+.compare-grid { display: grid; gap: 1.25rem; }
+.compare-grid__toolbar { grid-area: toolbar; }
+.compare-grid__chart { grid-area: chart; }
+.compare-grid__advanced { grid-area: advanced; }
+@media (min-width: 1200px) {
+  .compare-grid {
+    grid-template-columns: minmax(0, 1fr) 320px;
+    grid-template-areas:
+      "toolbar toolbar"
+      "chart advanced";
+    align-items: start;
+  }
+  .compare-grid__advanced { position: sticky; top: 72px; }
+}
+@media (max-width: 1199px) {
+  .compare-grid { grid-template-areas: "toolbar" "chart" "advanced"; }
+}
+.compare-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+  border: 1px solid rgba(var(--primary-rgb,11,31,59),0.18);
+  background: rgba(var(--surface-rgb,255,255,255),0.92);
+  backdrop-filter: blur(12px);
+  border-radius: 16px;
+  padding: 0.75rem 1rem;
+  min-height: 48px;
+  box-shadow: 0 18px 32px rgba(var(--primary-rgb,11,31,59),0.08);
+}
+.compare-toolbar .stColumns { gap: 0.75rem; }
+.compare-toolbar .stColumn { min-width: 220px; }
+.compare-toolbar .toolbar-actions { margin-left: auto; min-width: auto; }
+.compare-toolbar .stSlider, .compare-toolbar .stRadio { margin-bottom: 0 !important; }
+.compare-toolbar .toolbar-control { position: relative; display: flex; flex-direction: column; gap: 0.35rem; }
+.compare-toolbar .toolbar-header { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; font-weight: 600; font-size: 0.95rem; }
+.compare-toolbar .value-badge { background: rgba(var(--accent-rgb,30,136,229),0.12); color: var(--primary,#0B1F3B); border-radius: 999px; padding: 0.1rem 0.6rem; font-weight: 600; font-variant-numeric: tabular-nums; }
+.compare-toolbar button[data-testid="baseButton-secondary"], .compare-toolbar button[kind="secondary"] { border-radius: 999px; }
+@media (max-width: 767px) {
+  .compare-toolbar { flex-wrap: nowrap; overflow-x: auto; padding-bottom: 0.75rem; }
+  .compare-toolbar .stColumns { flex-wrap: nowrap; }
+  .compare-toolbar .stColumn { flex: 0 0 auto; min-width: 240px; }
+}
+.compare-grid__chart .chart-surface { border: 1px solid rgba(var(--primary-rgb,11,31,59),0.16); border-radius: 16px; background: var(--panel,#ffffff); padding: 1rem; box-shadow: 0 12px 28px rgba(var(--primary-rgb,11,31,59),0.07); }
+.compare-grid__advanced { transition: max-height 0.3s ease; }
+.compare-grid__advanced[data-open="false"] { max-height: 0; overflow: hidden; }
+@media (min-width: 1200px) {
+  .compare-grid__advanced { max-height: none !important; display: block !important; }
+}
+.advanced-panel { border: 1px solid rgba(var(--primary-rgb,11,31,59),0.16); border-radius: 16px; background: var(--panel,#ffffff); padding: 1rem 1.1rem; box-shadow: 0 12px 24px rgba(var(--primary-rgb,11,31,59),0.08); }
+.advanced-panel h4 { margin: 0 0 0.6rem; font-size: 0.95rem; font-weight: 600; color: var(--primary,#0B1F3B); }
+.advanced-section + .advanced-section { margin-top: 1.25rem; padding-top: 1.1rem; border-top: 1px solid rgba(var(--primary-rgb,11,31,59),0.08); }
+.advanced-panel .stRadio, .advanced-panel .stCheckbox, .advanced-panel .stSlider, .advanced-panel .stSelectbox, .advanced-panel .stNumberInput, .advanced-panel .stTextInput { margin-bottom: 0.6rem !important; }
+@media (max-width: 1199px) {
+  .compare-grid__advanced { border-radius: 16px; background: rgba(var(--surface-rgb,255,255,255),0.96); box-shadow: 0 10px 24px rgba(var(--primary-rgb,11,31,59),0.12); }
+}
+</style>
         """,
         unsafe_allow_html=True,
     )
 
-    st.markdown(
-        '<section class="chart-card" id="line-compare">', unsafe_allow_html=True
-    )
+    st.markdown('<section class="compare-shell" id="line-compare">', unsafe_allow_html=True)
+    st.markdown('<div class="compare-grid">', unsafe_allow_html=True)
 
-    st.markdown('<div class="chart-toolbar">', unsafe_allow_html=True)
-    c1, c2, c3, c4, c5 = st.columns([1.2, 1.6, 1.1, 1.0, 0.9])
-    with c1:
-        period = st.radio(
-            "期間", ["12ヶ月", "24ヶ月", "36ヶ月"], horizontal=True, index=1
-        )
-    with c2:
-        node_mode = st.radio(
-            "ノード表示",
-            ["自動", "主要ノードのみ", "すべて", "非表示"],
-            horizontal=True,
-            index=0,
-        )
-    with c3:
-        hover_mode = st.radio(
-            "ホバー", ["個別", "同月まとめ"], horizontal=True, index=0
-        )
-    with c4:
-        op_mode = st.radio("操作", ["パン", "ズーム", "選択"], horizontal=True, index=0)
-    with c5:
-        peak_on = st.checkbox("ピーク表示", value=False)
+    st.markdown('<div class="compare-grid__toolbar">', unsafe_allow_html=True)
+    st.markdown('<div class="compare-toolbar" role="group" aria-label="主要設定">', unsafe_allow_html=True)
+    toolbar_cols = st.columns([1, 1, 1, 1, 0.4], gap="medium")
 
-    c6, c7, c8 = st.columns([2.0, 1.9, 1.6])
-    with c6:
-        band_mode = st.radio(
-            "バンド",
-            ["金額指定", "商品指定(2)", "パーセンタイル", "順位帯", "ターゲット近傍"],
-            horizontal=True,
-            index=[
-                "金額指定",
-                "商品指定(2)",
-                "パーセンタイル",
-                "順位帯",
-                "ターゲット近傍",
-            ].index(params.get("band_mode", "金額指定")),
-        )
-    with c7:
-        if band_mode == "金額指定":
-            if not snapshot.empty:
-                unit_scale, unit_label = choose_amount_slider_unit(max_amount)
-                slider_max = int(
-                    math.ceil(
-                        max(
-                            max_amount,
-                            band_params_initial.get("high_amount", high0),
-                        )
-                        / unit_scale
-                    )
-                )
-                slider_max = max(slider_max, 1)
+    def _format_float(value: float, digits: int = 2) -> str:
+        return f"{value:.{digits}f}"
 
-                default_low = int(
-                    round(band_params_initial.get("low_amount", low0) / unit_scale)
-                )
-                default_high = int(
-                    round(band_params_initial.get("high_amount", high0) / unit_scale)
-                )
-                default_low = max(0, min(default_low, slider_max))
-                default_high = max(default_low, min(default_high, slider_max))
+    with toolbar_cols[0]:
+        st.markdown('<div class="toolbar-control">', unsafe_allow_html=True)
+        header = st.empty()
+        sens = st.slider(
+            "形状抽出の感度",
+            0.0,
+            1.0,
+            value=st.session_state.get("compare_sensitivity", 0.5),
+            step=0.05,
+            key="compare_sensitivity",
+            label_visibility="collapsed",
+        )
+        header.markdown(
+            f'<div class="toolbar-header">形状抽出の感度<span class="value-badge">{_format_float(sens)}</span></div>',
+            unsafe_allow_html=True,
+        )
+        st.markdown('</div>', unsafe_allow_html=True)
 
-                step = nice_slider_step(slider_max)
+    with toolbar_cols[1]:
+        st.markdown('<div class="toolbar-control">', unsafe_allow_html=True)
+        header = st.empty()
+        z_thr = st.slider(
+            "急勾配 zスコア",
+            0.0,
+            3.0,
+            value=st.session_state.get("compare_z_threshold", 0.0),
+            step=0.1,
+            key="compare_z_threshold",
+            label_visibility="collapsed",
+        )
+        header.markdown(
+            f'<div class="toolbar-header">急勾配 zスコア<span class="value-badge">{_format_float(z_thr, 2)}</span></div>',
+            unsafe_allow_html=True,
+        )
+        st.markdown('</div>', unsafe_allow_html=True)
 
-                amount_slider_cfg = dict(
-                    label=f"金額レンジ（{unit_label}単位）",
-                    min_value=0,
-                    max_value=slider_max,
-                    value=(default_low, default_high),
-                    step=step,
-                    unit_scale=unit_scale,
-                    unit_label=unit_label,
-                    max_amount=max_amount,
-                )
-            else:
-                band_params = {"low_amount": low0, "high_amount": high0}
-        elif band_mode == "商品指定(2)":
-            if not snapshot.empty:
-                opts = (
-                    snapshot["product_code"].fillna("")
-                    + " | "
-                    + snapshot["display_name"].fillna("")
-                ).tolist()
-                opts = [o for o in opts if o.strip() != "|"]
-                prod_a = st.selectbox("商品A", opts, index=0)
-                prod_b = st.selectbox("商品B", opts, index=1 if len(opts) > 1 else 0)
-                band_params = {
-                    "prod_a": prod_a.split(" | ")[0],
-                    "prod_b": prod_b.split(" | ")[0],
-                }
-            else:
-                band_params = band_params_initial
-        elif band_mode == "パーセンタイル":
-            if not snapshot.empty:
-                p_low = band_params_initial.get("p_low", 0)
-                p_high = band_params_initial.get("p_high", 100)
-                p_low, p_high = st.slider(
-                    "百分位(%)", 0, 100, (int(p_low), int(p_high))
-                )
-                band_params = {"p_low": p_low, "p_high": p_high}
-            else:
-                band_params = {
-                    "p_low": band_params_initial.get("p_low", 0),
-                    "p_high": band_params_initial.get("p_high", 100),
-                }
-        elif band_mode == "順位帯":
-            if not snapshot.empty:
-                max_rank = int(snapshot["rank"].max()) if not snapshot.empty else 1
-                r_low = band_params_initial.get("r_low", 1)
-                r_high = band_params_initial.get("r_high", max_rank)
-                r_low, r_high = st.slider(
-                    "順位", 1, max_rank, (int(r_low), int(r_high))
-                )
-                band_params = {"r_low": r_low, "r_high": r_high}
-            else:
-                band_params = {
-                    "r_low": band_params_initial.get("r_low", 1),
-                    "r_high": band_params_initial.get("r_high", 1),
-                }
-        else:
-            opts = (
-                snapshot["product_code"] + " | " + snapshot["display_name"]
-            ).tolist()
-            tlabel = st.selectbox("基準商品", opts, index=0) if opts else ""
-            tcode = tlabel.split(" | ")[0] if tlabel else ""
-            by_default = band_params_initial.get("by", "amt")
-            by_index = 0 if by_default == "amt" else 1
-            by = st.radio("幅指定", ["金額", "%"], horizontal=True, index=by_index)
-            if by == "金額":
-                width_default = 100000
-                width = int_input(
-                    "幅", int(band_params_initial.get("width", width_default))
-                )
-                band_params = {"target_code": tcode, "by": "amt", "width": int(width)}
-            else:
-                width_default = 0.1
-                width = st.number_input(
-                    "幅",
-                    value=float(band_params_initial.get("width", width_default)),
-                    step=width_default / 10 if width_default else 0.01,
-                )
-                band_params = {"target_code": tcode, "by": "pct", "width": width}
-    with c8:
-        quick = st.radio(
-            "クイック絞り込み",
-            ["なし", "Top5", "Top10", "最新YoY上位", "直近6M伸長上位"],
-            horizontal=True,
-            index=0,
-        )
-    c9, c10, c11, c12 = st.columns([1.2, 1.5, 1.5, 1.5])
-    with c9:
-        enable_label_avoid = st.checkbox("ラベル衝突回避", value=True)
-    with c10:
-        label_gap_px = st.slider("ラベル最小間隔(px)", 8, 24, 12)
-    with c11:
-        label_max = st.slider("ラベル最大件数", 5, 20, 12)
-    with c12:
-        alternate_side = st.checkbox("ラベル左右交互配置", value=True)
-    c13, c14, c15, c16, c17 = st.columns([1.0, 1.4, 1.2, 1.2, 1.2])
-    with c13:
-        unit = st.radio("単位", ["円", "千円", "百万円"], horizontal=True, index=1)
-    with c14:
-        n_win = st.slider(
-            "傾きウィンドウ（月）",
-            0,
-            12,
-            6,
-            1,
-            help="0=自動（系列の全期間で判定）",
-        )
-    with c15:
-        cmp_mode = st.radio("傾き条件", ["以上", "未満"], horizontal=True)
-    with c16:
-        thr_type = st.radio(
-            "しきい値の種類", ["円/月", "%/月", "zスコア"], horizontal=True
-        )
-    with c17:
-        if thr_type == "円/月":
-            thr_val = int_input("しきい値", 0)
-        else:
-            thr_val = st.number_input("しきい値", value=0.0, step=0.01, format="%.2f")
-    c18, c19, c20 = st.columns([1.6, 1.2, 1.8])
-    with c18:
-        sens = st.slider("形状抽出の感度", 0.0, 1.0, 0.5, 0.05)
-    with c19:
-        z_thr = st.slider("急勾配 zスコア", 0.0, 3.0, 0.0, 0.1)
-    with c20:
+    with toolbar_cols[2]:
+        st.markdown('<div class="toolbar-control">', unsafe_allow_html=True)
+        header = st.empty()
         shape_pick = st.radio(
             "形状抽出",
             ["（なし）", "急勾配", "山（への字）", "谷（逆への字）"],
             horizontal=True,
+            key="compare_shape_pick",
+            label_visibility="collapsed",
         )
-    st.markdown("</div>", unsafe_allow_html=True)
+        header.markdown(
+            f'<div class="toolbar-header">形状抽出<span class="value-badge">{html.escape(shape_pick.replace("（", "").replace("）", ""))}</span></div>',
+            unsafe_allow_html=True,
+        )
+        st.markdown('</div>', unsafe_allow_html=True)
 
-    st.markdown('<div class="chart-body">', unsafe_allow_html=True)
+    with toolbar_cols[3]:
+        st.markdown('<div class="toolbar-control">', unsafe_allow_html=True)
+        header = st.empty()
+        if amount_slider_cfg:
+            low_scaled, high_scaled = st.slider(
+                amount_slider_cfg["label"],
+                min_value=amount_slider_cfg["min_value"],
+                max_value=amount_slider_cfg["max_value"],
+                value=st.session_state.get("compare_amount_range", amount_slider_cfg["value"]),
+                step=amount_slider_cfg["step"],
+                key="compare_amount_range",
+                label_visibility="collapsed",
+            )
+            low = int(low_scaled * amount_slider_cfg["unit_scale"])
+            high = int(high_scaled * amount_slider_cfg["unit_scale"])
+            high = min(high, amount_slider_cfg["max_amount"])
+            low = min(low, high)
+            badge = f"{format_int(low)}〜{format_int(high)}"
+            band_params = {"low_amount": low, "high_amount": high}
+        else:
+            badge = "設定なし"
+        header.markdown(
+            f'<div class="toolbar-header">金額レンジ<span class="value-badge">{badge}</span></div>',
+            unsafe_allow_html=True,
+        )
+        if band_mode != "金額指定":
+            st.caption("金額指定モードでレンジ設定が有効になります。")
+        elif amount_slider_cfg is None:
+            st.caption("対象データがありません。")
+        st.markdown('</div>', unsafe_allow_html=True)
+
+    with toolbar_cols[4]:
+        st.markdown('<div class="toolbar-control toolbar-actions">', unsafe_allow_html=True)
+        toggle_label = "詳細設定を閉じる" if st.session_state.compare_details_open else "詳細設定"
+        if st.button(toggle_label, key="compare_details_toggle", help="表示項目を追加で調整"):
+            st.session_state.compare_details_open = not st.session_state.compare_details_open
+        st.markdown('</div>', unsafe_allow_html=True)
+
+    st.markdown('</div>', unsafe_allow_html=True)
+    st.markdown('</div>', unsafe_allow_html=True)
+
+    details_open = st.session_state.compare_details_open
+
+    st.markdown(
+        f'<div class="compare-grid__advanced" data-open="{str(details_open).lower()}">',
+        unsafe_allow_html=True,
+    )
+    st.markdown('<div class="advanced-panel" role="region" aria-label="詳細設定">', unsafe_allow_html=True)
+
+    st.markdown('<div class="advanced-section">', unsafe_allow_html=True)
+    st.markdown('<h4>表示</h4>', unsafe_allow_html=True)
+    display_cols = st.columns(2)
+    with display_cols[0]:
+        period = st.radio(
+            "期間",
+            ["12ヶ月", "24ヶ月", "36ヶ月"],
+            horizontal=True,
+            index=["12ヶ月", "24ヶ月", "36ヶ月"].index(st.session_state.get("compare_period", "24ヶ月")),
+            key="compare_period",
+        )
+        op_mode = st.radio(
+            "操作",
+            ["パン", "ズーム", "選択"],
+            horizontal=True,
+            index=["パン", "ズーム", "選択"].index(st.session_state.get("compare_op_mode", "パン")),
+            key="compare_op_mode",
+        )
+    with display_cols[1]:
+        node_mode = st.radio(
+            "ノード表示",
+            ["自動", "主要ノードのみ", "すべて", "非表示"],
+            horizontal=True,
+            index=["自動", "主要ノードのみ", "すべて", "非表示"].index(st.session_state.get("compare_node_mode", "自動")),
+            key="compare_node_mode",
+        )
+        hover_mode = st.radio(
+            "ホバー",
+            ["個別", "同月まとめ"],
+            horizontal=True,
+            index=["個別", "同月まとめ"].index(st.session_state.get("compare_hover_mode", "個別")),
+            key="compare_hover_mode",
+        )
+    peak_on = st.checkbox(
+        "ピーク表示",
+        value=st.session_state.get("compare_peak_on", False),
+        key="compare_peak_on",
+    )
+    st.markdown('</div>', unsafe_allow_html=True)
+
+    st.markdown('<div class="advanced-section">', unsafe_allow_html=True)
+    st.markdown('<h4>抽出条件</h4>', unsafe_allow_html=True)
+    band_options = ["金額指定", "商品指定(2)", "パーセンタイル", "順位帯", "ターゲット近傍"]
+    band_mode = st.radio(
+        "バンド",
+        band_options,
+        horizontal=True,
+        index=band_options.index(band_mode) if band_mode in band_options else 0,
+        key="compare_band_mode",
+    )
+    if band_mode == "商品指定(2)":
+        if not snapshot.empty:
+            opts = (
+                snapshot["product_code"].fillna("")
+                + " | "
+                + snapshot["display_name"].fillna("")
+            ).tolist()
+            opts = [o for o in opts if o.strip() != "|"]
+            idx_a = 0
+            idx_b = 1 if len(opts) > 1 else 0
+            if band_params.get("prod_a"):
+                idx_a = next(
+                    (i for i, o in enumerate(opts) if o.split(" | ")[0] == band_params.get("prod_a")),
+                    0,
+                )
+            if band_params.get("prod_b"):
+                idx_b = next(
+                    (i for i, o in enumerate(opts) if o.split(" | ")[0] == band_params.get("prod_b")),
+                    1 if len(opts) > 1 else 0,
+                )
+            prod_a = st.selectbox("商品A", opts, index=idx_a, key="compare_prod_a") if opts else ""
+            prod_b = st.selectbox("商品B", opts, index=idx_b, key="compare_prod_b") if len(opts) > 1 else prod_a
+            band_params = {
+                "prod_a": prod_a.split(" | ")[0] if prod_a else "",
+                "prod_b": prod_b.split(" | ")[0] if prod_b else "",
+            }
+        else:
+            band_params = band_params_initial
+    elif band_mode == "パーセンタイル":
+        if not snapshot.empty:
+            p_low = int(band_params.get("p_low", 0))
+            p_high = int(band_params.get("p_high", 100))
+            p_low, p_high = st.slider(
+                "百分位(%)",
+                0,
+                100,
+                value=(p_low, p_high),
+                key="compare_percentile_range",
+            )
+            band_params = {"p_low": p_low, "p_high": p_high}
+        else:
+            band_params = {"p_low": band_params.get("p_low", 0), "p_high": band_params.get("p_high", 100)}
+    elif band_mode == "順位帯":
+        if not snapshot.empty:
+            max_rank = int(snapshot["rank"].max()) if not snapshot.empty else 1
+            r_low = int(band_params.get("r_low", 1))
+            r_high = int(band_params.get("r_high", max_rank))
+            r_low, r_high = st.slider(
+                "順位",
+                1,
+                max_rank,
+                value=(r_low, min(r_high, max_rank)),
+                key="compare_rank_range",
+            )
+            band_params = {"r_low": r_low, "r_high": r_high}
+        else:
+            band_params = {
+                "r_low": int(band_params.get("r_low", 1)),
+                "r_high": int(band_params.get("r_high", 1)),
+            }
+    elif band_mode == "ターゲット近傍":
+        opts = (
+            snapshot["product_code"].fillna("") + " | " + snapshot["display_name"].fillna("")
+        ).tolist()
+        idx = 0
+        if band_params.get("target_code"):
+            idx = next(
+                (i for i, o in enumerate(opts) if o.split(" | ")[0] == band_params.get("target_code")),
+                0,
+            )
+        tlabel = st.selectbox("基準商品", opts, index=idx, key="compare_target_label") if opts else ""
+        tcode = tlabel.split(" | ")[0] if tlabel else ""
+        by = st.radio(
+            "幅指定",
+            ["金額", "%"],
+            horizontal=True,
+            index=0 if band_params.get("by", "amt") == "amt" else 1,
+            key="compare_band_by",
+        )
+        if by == "金額":
+            width_default = int(band_params.get("width", 100000))
+            width = int_input("幅", width_default)
+            band_params = {"target_code": tcode, "by": "amt", "width": int(width)}
+        else:
+            width_default = float(band_params.get("width", 0.1))
+            step = width_default / 10 if width_default else 0.01
+            width = st.number_input(
+                "幅",
+                value=width_default,
+                step=step,
+                key="compare_band_width_pct",
+            )
+            band_params = {"target_code": tcode, "by": "pct", "width": float(width)}
+
+    quick = st.radio(
+        "クイック絞り込み",
+        ["なし", "Top5", "Top10", "最新YoY上位", "直近6M伸長上位"],
+        horizontal=True,
+        index=["なし", "Top5", "Top10", "最新YoY上位", "直近6M伸長上位"].index(st.session_state.get("compare_quick", "なし")),
+        key="compare_quick",
+    )
+    st.markdown('</div>', unsafe_allow_html=True)
+
+    st.markdown('<div class="advanced-section">', unsafe_allow_html=True)
+    st.markdown('<h4>ラベル・表示</h4>', unsafe_allow_html=True)
+    label_cols = st.columns(2)
+    with label_cols[0]:
+        enable_label_avoid = st.checkbox(
+            "ラベル衝突回避",
+            value=st.session_state.get("compare_label_avoid", True),
+            key="compare_label_avoid",
+        )
+        alternate_side = st.checkbox(
+            "ラベル左右交互配置",
+            value=st.session_state.get("compare_alternate_side", True),
+            key="compare_alternate_side",
+        )
+    with label_cols[1]:
+        label_gap_px = st.slider(
+            "ラベル最小間隔(px)",
+            8,
+            24,
+            st.session_state.get("compare_label_gap", 12),
+            key="compare_label_gap",
+        )
+        label_max = st.slider(
+            "ラベル最大件数",
+            5,
+            20,
+            st.session_state.get("compare_label_max", 12),
+            key="compare_label_max",
+        )
+    unit = st.radio(
+        "単位",
+        ["円", "千円", "百万円"],
+        horizontal=True,
+        index=["円", "千円", "百万円"].index(st.session_state.get("compare_unit", "千円")),
+        key="compare_unit",
+    )
+    st.markdown('</div>', unsafe_allow_html=True)
+
+    st.markdown('<div class="advanced-section">', unsafe_allow_html=True)
+    st.markdown('<h4>傾き検出</h4>', unsafe_allow_html=True)
+    slope_cols = st.columns(2)
+    with slope_cols[0]:
+        n_win = st.slider(
+            "傾きウィンドウ（月）",
+            0,
+            12,
+            st.session_state.get("compare_n_win", 6),
+            1,
+            help="0=自動（系列の全期間で判定）",
+            key="compare_n_win",
+        )
+        cmp_mode = st.radio(
+            "傾き条件",
+            ["以上", "未満"],
+            horizontal=True,
+            index=["以上", "未満"].index(st.session_state.get("compare_cmp_mode", "以上")),
+            key="compare_cmp_mode",
+        )
+    with slope_cols[1]:
+        thr_type = st.radio(
+            "しきい値の種類",
+            ["円/月", "%/月", "zスコア"],
+            horizontal=True,
+            index=["円/月", "%/月", "zスコア"].index(st.session_state.get("compare_thr_type", "円/月")),
+            key="compare_thr_type",
+        )
+        if thr_type == "円/月":
+            thr_val = int_input(
+                "しきい値",
+                st.session_state.get("compare_thr_val_int", 0),
+            )
+            st.session_state.compare_thr_val_int = thr_val
+        else:
+            thr_val = st.number_input(
+                "しきい値",
+                value=float(st.session_state.get("compare_thr_val_float", 0.0)),
+                step=0.01,
+                format="%.2f",
+                key="compare_thr_val_float",
+            )
+            st.session_state.compare_thr_val_float = float(thr_val)
+    st.markdown('</div>', unsafe_allow_html=True)
+
+    st.markdown('</div>', unsafe_allow_html=True)
+    st.markdown('</div>', unsafe_allow_html=True)
+
+    st.markdown('<div class="compare-grid__chart">', unsafe_allow_html=True)
+    st.markdown('<section class="chart-surface" aria-label="メインチャート">', unsafe_allow_html=True)
     ai_summary_container = st.container()
 
     if amount_slider_cfg:
-        low_scaled, high_scaled = st.slider(
-            amount_slider_cfg["label"],
-            min_value=amount_slider_cfg["min_value"],
-            max_value=amount_slider_cfg["max_value"],
-            value=amount_slider_cfg["value"],
-            step=amount_slider_cfg["step"],
+        low_scaled, high_scaled = st.session_state.get(
+            "compare_amount_range", amount_slider_cfg["value"]
         )
         low = int(low_scaled * amount_slider_cfg["unit_scale"])
         high = int(high_scaled * amount_slider_cfg["unit_scale"])
         high = min(high, amount_slider_cfg["max_amount"])
         low = min(low, high)
-        st.caption(f"選択中: {format_int(low)}円 〜 {format_int(high)}円")
         band_params = {"low_amount": low, "high_amount": high}
     elif band_mode == "金額指定":
         band_params = {"low_amount": low0, "high_amount": high0}
@@ -11946,6 +12205,8 @@ elif page == "比較ビュー":
         tb=tb_common,
         band_range=(low, high),
     )
+    st.markdown("</section>", unsafe_allow_html=True)
+    st.markdown("</div>", unsafe_allow_html=True)
     st.markdown("</div>", unsafe_allow_html=True)
     st.markdown("</section>", unsafe_allow_html=True)
 


### PR DESCRIPTION
## Summary
- move the primary shape-detection controls into a new inline toolbar directly above the chart with responsive styling
- consolidate secondary controls into a sticky advanced panel on desktop and collapsible section on smaller screens
- persist toolbar selections in `st.session_state` so the chart refreshes immediately after each adjustment

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d7c0493fd4832388c03748ec618e3e