### PR TITLE
Fix Streamlit expander key error in compare details panel

### DIFF
--- a/app.py
+++ b/app.py
@@ -11867,7 +11867,7 @@ elif page == "比較ビュー":
     chart_body_placeholder = st.container()
 
     st.markdown('<div class="chart-accordion">', unsafe_allow_html=True)
-    with st.expander("詳細設定", expanded=False, key="compare_details_panel"):
+    with st.expander("詳細設定", expanded=False):
         st.markdown("#### 表示")
         display_cols = st.columns(2)
         with display_cols[0]:


### PR DESCRIPTION
## Summary
- remove the unsupported key argument from the compare details panel expander to prevent Streamlit from raising a TypeError

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7cff2687883239eb194c704754cfd